### PR TITLE
Added localized keyword support

### DIFF
--- a/Kernel/Config/Files/WarnMissingAttachment.xml
+++ b/Kernel/Config/Files/WarnMissingAttachment.xml
@@ -30,14 +30,98 @@
             </Hash>
         </Setting>
     </ConfigItem>
-   <ConfigItem Name="WarnMissingAttachment::Keywords" Required="1" Valid="1">
-        <Description Translatable="1">Keywords that indicates that an attachment should be sent.</Description>
+    <ConfigItem Name="WarnMissingAttachment::Keywords###de" Required="1" Valid="1">
+        <Description Translatable="1">German keywords that indicates that an attachment should be sent.</Description>
+        <Group>WarnMissingAttachment</Group>
+        <SubGroup>Core::WarnMissingAttachment</SubGroup>
+        <Setting>
+            <Array>
+                <Item></Item>
+            </Array>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="WarnMissingAttachment::Keywords###en" Required="1" Valid="1">
+        <Description Translatable="1">English keywords that indicates that an attachment should be sent.</Description>
         <Group>WarnMissingAttachment</Group>
         <SubGroup>Core::WarnMissingAttachment</SubGroup>
         <Setting>
             <Array>
                 <Item>attach</Item>
-                <Item>Attachment</Item>
+                <Item>attaching</Item>
+                <Item>attaches</Item>
+                <Item>attachment</Item>
+                <Item>attachments</Item>
+                <Item>attached</Item>
+                <Item>document</Item>
+                <Item>documents</Item>
+                <Item>enclose</Item>
+                <Item>enclosed</Item>
+                <Item>enclosing</Item>
+                <Item>encloses</Item>
+                <Item>enclosure</Item>
+                <Item>enclosures</Item>
+                <Item>file</Item>
+                <Item>files</Item>
+                <Item>letter</Item>
+            </Array>
+        </Setting>
+    </ConfigItem>
+    <ConfigItem Name="WarnMissingAttachment::Keywords###hu" Required="1" Valid="1">
+        <Description Translatable="1">Hungarian keywords that indicates that an attachment should be sent.</Description>
+        <Group>WarnMissingAttachment</Group>
+        <SubGroup>Core::WarnMissingAttachment</SubGroup>
+        <Setting>
+            <Array>
+                <Item>állomány</Item>
+                <Item>állományt</Item>
+                <Item>állománynak</Item>
+                <Item>állományok</Item>
+                <Item>állományokat</Item>
+                <Item>állományoknak</Item>
+                <Item>csatol</Item>
+                <Item>csatolás</Item>
+                <Item>csatolást</Item>
+                <Item>csatolásnak</Item>
+                <Item>csatolások</Item>
+                <Item>csatolásokat</Item>
+                <Item>csatolásoknak</Item>
+                <Item>csatolmány</Item>
+                <Item>csatolmányt</Item>
+                <Item>csatolmánynak</Item>
+                <Item>csatolmányok</Item>
+                <Item>csatolmányokat</Item>
+                <Item>csatolmányoknak</Item>
+                <Item>csatolva</Item>
+                <Item>csatolom</Item>
+                <Item>csatoltam</Item>
+                <Item>dokumentum</Item>
+                <Item>dokumentumot</Item>
+                <Item>dokumentumnak</Item>
+                <Item>dokumentumok</Item>
+                <Item>dokumentumokat</Item>
+                <Item>dokumentumoknak</Item>
+                <Item>fájl</Item>
+                <Item>fájlt</Item>
+                <Item>fájlnak</Item>
+                <Item>fájlok</Item>
+                <Item>fájlokat</Item>
+                <Item>fájloknak</Item>
+                <Item>mellékel</Item>
+                <Item>mellékelem</Item>
+                <Item>mellékelve</Item>
+                <Item>mellékeltem</Item>
+                <Item>melléklet</Item>
+                <Item>mellékletet</Item>
+                <Item>mellékletnek</Item>
+                <Item>mellékletek</Item>
+                <Item>mellékleteket</Item>
+                <Item>mellékleteknek</Item>
+                <Item>küldöm</Item>
+                <Item>elküldöm</Item>
+                <Item>átküldöm</Item>
+                <Item>küldött</Item>
+                <Item>elküldött</Item>
+                <Item>átküldött</Item>
             </Array>
         </Setting>
     </ConfigItem>

--- a/Kernel/Language/de_WarnMissingAttachment.pm
+++ b/Kernel/Language/de_WarnMissingAttachment.pm
@@ -26,7 +26,9 @@ sub Data {
     # Kernel/Config/Files/WarnMissingAttachment.xml
     $Lang->{'List of screens that are affected by this modul.'} = '';
     $Lang->{'Names of Body fields.'} = '';
-    $Lang->{'Keywords that indicates that an attachment should be sent.'} = '';
+    $Lang->{'German keywords that indicates that an attachment should be sent.'} = '';
+    $Lang->{'English keywords that indicates that an attachment should be sent.'} = '';
+    $Lang->{'Hungarian keywords that indicates that an attachment should be sent.'} = '';
 
     # Kernel/Output/HTML/Templates/Standard/WarnMissingAttachmentJS.tt
     $Lang->{'Sending without Attachment'} = 'Absenden ohne Anhang';

--- a/Kernel/Language/hu_WarnMissingAttachment.pm
+++ b/Kernel/Language/hu_WarnMissingAttachment.pm
@@ -27,8 +27,12 @@ sub Data {
     # Kernel/Config/Files/WarnMissingAttachment.xml
     $Lang->{'List of screens that are affected by this modul.'} = 'Képernyők listája, amelyeket ez a modul érint.';
     $Lang->{'Names of Body fields.'} = 'A törzsmezők nevei.';
-    $Lang->{'Keywords that indicates that an attachment should be sent.'} =
-        'Kulcsszavak, amelyek azt jelzik, hogy mellékletet kellene küldeni.';
+    $Lang->{'German keywords that indicates that an attachment should be sent.'} =
+        'Német kulcsszavak, amelyek azt jelzik, hogy mellékletet kellene küldeni.';
+    $Lang->{'English keywords that indicates that an attachment should be sent.'} =
+        'Angol kulcsszavak, amelyek azt jelzik, hogy mellékletet kellene küldeni.';
+    $Lang->{'Hungarian keywords that indicates that an attachment should be sent.'} =
+        'Magyar kulcsszavak, amelyek azt jelzik, hogy mellékletet kellene küldeni.';
 
     # Kernel/Output/HTML/Templates/Standard/WarnMissingAttachmentJS.tt
     $Lang->{'Sending without Attachment'} = 'Küldés melléklet nélkül';

--- a/WarnMissingAttachment.sopm
+++ b/WarnMissingAttachment.sopm
@@ -2,7 +2,7 @@
 <otrs_package version="1.0">
     <!-- GENERATED WITH OTRS::OPM::Maker::Command::sopm (1.33) -->
     <Name>WarnMissingAttachment</Name>
-    <Version>5.0.2</Version>
+    <Version>5.0.3</Version>
     <Framework>5.0.x</Framework>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de</URL>


### PR DESCRIPTION
Hi @reneeb 

This is only a proposal, it **doesn't work** in this state! I suggest this, because every languages have its own keywords, so it would be useful to set some defaults for them.
Why doesn't work? I don't know, but I guess [these lines](https://github.com/reneeb/otrs-WarnMissingAttachment/blob/master/Kernel/Output/HTML/Templates/Standard/WarnMissingAttachmentJS.tt#L42-L44) should be modified. Can you help me to fix this?

Which functionality would be better?
1.) The template renders only the corresponding keywords (e. g. only Hungarian keywords for Hungarian UI)
2.) The template renders all keywords (because a Hungarian agent can write English article)

Or let the admin chose between 1.) and 2.) via a new SysConfig setting?
